### PR TITLE
Remove unnecessary workspace validation in extension

### DIFF
--- a/pydance/src/extension.ts
+++ b/pydance/src/extension.ts
@@ -16,20 +16,6 @@ export function activate(context: vscode.ExtensionContext) {
   const serverPath = context.asAbsolutePath(path.join("pylight"));
   outputChannel.appendLine(`Server path: ${serverPath}`);
 
-  // Get the workspace root path
-  const workspaceRoot =
-    vscode.workspace.workspaceFolders &&
-    vscode.workspace.workspaceFolders.length > 0
-      ? vscode.workspace.workspaceFolders[0].uri.fsPath
-      : undefined;
-
-  if (!workspaceRoot) {
-    outputChannel.appendLine("No workspace folder found. Server not starting.");
-    return;
-  }
-
-  outputChannel.appendLine(`Workspace root: ${workspaceRoot}`);
-
   // If the extension is launched in debug mode then the debug server options are used
   const serverOptions: ServerOptions = {
     run: { command: serverPath, args: [] },


### PR DESCRIPTION
## Summary
- Removed the workspace folder existence check that was preventing the language server from starting without an open workspace
- Simplified the extension activation logic by removing 14 lines of unnecessary validation code

## Rationale
The previous implementation was overly restrictive by refusing to start the language server when no workspace folder was present. This cleanup addresses several issues:

1. **LSP Best Practices**: According to VSCode and LSP documentation, language servers should be able to operate without a workspace (single file mode)
2. **Automatic Workspace Handling**: Workspace information is automatically communicated through the LSP protocol's initialization handshake
3. **Flexibility**: The LSP specification explicitly allows for null workspace folders

## Changes
- Removed `workspaceRoot` variable and validation logic from `extension.ts`
- The language server now starts regardless of workspace presence
- Tests remain unchanged as they already handle workspace absence appropriately

## Test Results
- ✅ All tests pass (`npm test`)
- ✅ No linting errors (`npm run lint`)
- ✅ Code formatting verified (`npm run format`)

🤖 Generated with [Claude Code](https://claude.ai/code)