### PR TITLE
Remove redundant configurations and clean up extension

### DIFF
--- a/pydance/package.json
+++ b/pydance/package.json
@@ -20,18 +20,6 @@
     ],
     "main": "./out/extension.js",
     "contributes": {
-        "languages": [
-            {
-                "id": "python",
-                "aliases": [
-                    "Python",
-                    "python"
-                ],
-                "extensions": [
-                    ".py"
-                ]
-            }
-        ],
         "configuration": {
             "title": "Pydance",
             "properties": {
@@ -40,6 +28,20 @@
                     "default": "ruff",
                     "enum": ["ruff", "tree-sitter"],
                     "description": "Parser backend to use for Python code analysis"
+                },
+                "pydance.trace.server": {
+                    "type": "string",
+                    "default": "off",
+                    "enum": ["off", "messages", "verbose"],
+                    "description": "Traces the communication between VS Code and the language server"
+                },
+                "pydance.excludePatterns": {
+                    "type": "array",
+                    "default": [],
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "Glob patterns for directories to exclude from indexing"
                 }
             }
         }

--- a/pydance/src/extension.ts
+++ b/pydance/src/extension.ts
@@ -16,9 +16,11 @@ export function activate(context: vscode.ExtensionContext) {
   const serverPath = context.asAbsolutePath(path.join("pylight"));
   outputChannel.appendLine(`Server path: ${serverPath}`);
 
-  // Get the parser configuration
+  // Get configuration
   const config = vscode.workspace.getConfiguration("pydance");
   const parser = config.get<string>("parser", "ruff");
+  const traceLevel = config.get<string>("trace.server", "off");
+  const excludePatterns = config.get<string[]>("excludePatterns", []);
   outputChannel.appendLine(`Using parser: ${parser}`);
   // If the extension is launched in debug mode then the debug server options are used
   const serverOptions: ServerOptions = {
@@ -30,19 +32,10 @@ export function activate(context: vscode.ExtensionContext) {
   const clientOptions: LanguageClientOptions = {
     // Register the server for Python documents
     documentSelector: [{ scheme: "file", language: "python" }],
-    synchronize: {
-      // Notify the server about file changes to Python files in the workspace
-      fileEvents: vscode.workspace.createFileSystemWatcher(
-        "**/*.py",
-        false,
-        true,
-        true
-      ), // Ignore changes in .venv
-    },
     outputChannel: outputChannel,
     // traceOutputChannel: outputChannel,
     initializationOptions: {
-      excludePatterns: ["**/.venv/**", "**/venv/**", "**/.env/**", "**/env/**"],
+      excludePatterns: excludePatterns,
     },
   };
 
@@ -55,9 +48,13 @@ export function activate(context: vscode.ExtensionContext) {
     clientOptions
   );
 
-  // verbose logging of the LSP client's interactions with the server
-  // turn off when packaging the extension (make it configurable)
-  client.setTrace(Trace.Verbose);
+  // Set trace level based on configuration
+  const traceMap: { [key: string]: Trace } = {
+    off: Trace.Off,
+    messages: Trace.Messages,
+    verbose: Trace.Verbose,
+  };
+  client.setTrace(traceMap[traceLevel] || Trace.Off);
 
   outputChannel.appendLine("Starting language client...");
   // Start the client. This will also launch the server

--- a/pydance/src/test/suite/helper.ts
+++ b/pydance/src/test/suite/helper.ts
@@ -1,11 +1,6 @@
 import * as vscode from "vscode";
 import * as path from "path";
 
-export let doc: vscode.TextDocument;
-export let editor: vscode.TextEditor;
-export let documentEol: string;
-export let platformEol: string;
-
 /**
  * Activates the pydance extension
  */
@@ -14,8 +9,8 @@ export async function activate(docUri: vscode.Uri) {
   const ext = vscode.extensions.getExtension("ToughType.pydance")!;
   await ext.activate();
   try {
-    doc = await vscode.workspace.openTextDocument(docUri);
-    editor = await vscode.window.showTextDocument(doc);
+    const doc = await vscode.workspace.openTextDocument(docUri);
+    await vscode.window.showTextDocument(doc);
     await sleep(2000); // Wait for language server activation
   } catch (e) {
     console.error(e);
@@ -26,18 +21,10 @@ async function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-export const getDocPath = (p: string) => {
+const getDocPath = (p: string) => {
   return path.resolve(__dirname, "../../../src/testFixture", p);
 };
 
 export const getDocUri = (p: string) => {
   return vscode.Uri.file(getDocPath(p));
 };
-
-export async function setTestContent(content: string): Promise<boolean> {
-  const all = new vscode.Range(
-    doc.positionAt(0),
-    doc.positionAt(doc.getText().length)
-  );
-  return editor.edit((eb) => eb.replace(all, content));
-}


### PR DESCRIPTION
## Summary
- Removed redundant file system watcher since pylight handles file watching internally
- Made LSP tracing configurable (defaults to "off" instead of verbose)
- Removed redundant Python language registration that VS Code already provides
- Made exclude patterns user-configurable with empty default
- Cleaned up 6 unused test utility exports

## Details

### File System Watcher
The extension was creating a VS Code file watcher for Python files, but this is redundant since pylight already implements its own file watching. This eliminates:
- Double file watching overhead
- Unnecessary IPC messages for file change notifications
- Memory overhead from duplicate watchers

### Configuration Changes
Added two new settings:
- `pydance.trace.server`: Control LSP trace verbosity (off/messages/verbose)
- `pydance.excludePatterns`: User-configurable exclude patterns (empty by default)

### Code Cleanup
- Removed hardcoded virtual environment exclusions - users can now configure their own
- Removed unused test utilities that were never referenced
- Removed redundant Python language contribution from package.json

## Test Plan
- [x] Run formatter and linter (`npm run format:check && npm run lint`)
- [x] Run tests (`npm test`)
- [x] Verify extension still activates on Python files
- [x] Verify workspace symbol search still works
- [x] Test new configuration options work as expected

🤖 Generated with [Claude Code](https://claude.ai/code)