### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/pydance/package.json
+++ b/pydance/package.json
@@ -2,7 +2,7 @@
     "name": "pydance",
     "displayName": "Pydance",
     "description": "Python language server that provides high-performance workspace symbol search for large Python codebases",
-    "version": "0.1.4",
+    "version": "0.2.0",
     "publisher": "ToughType",
     "icon": "images/pydance-logo.png",
     "repository": {


### PR DESCRIPTION
## Summary
- Bumps pydance version from 0.1.4 to 0.2.0 in package.json

## Test plan
- [x] Verify version number is correctly updated in package.json
- [x] Ensure extension builds and packages successfully
- [ ] Check that version displays correctly in VS Code extension marketplace

🤖 Generated with [Claude Code](https://claude.ai/code)