### PR TITLE
chore: bump version to 0.2.1

### DIFF
--- a/pydance/package.json
+++ b/pydance/package.json
@@ -2,7 +2,7 @@
     "name": "pydance",
     "displayName": "Pydance",
     "description": "Python language server that provides high-performance workspace symbol search for large Python codebases",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "publisher": "ToughType",
     "icon": "images/pydance-logo.png",
     "repository": {


### PR DESCRIPTION
## Summary
- Bump pydance version from 0.2.0 to 0.2.1

## Test plan
- CI/CD tests should pass automatically
- No functional changes, version bump only

🤖 Generated with [Claude Code](https://claude.ai/code)