### PR TITLE
ci: replace deprecated actions-rs/toolchain with dtolnay/rust-toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,8 @@ jobs:
     - uses: actions/checkout@v4
     
     - name: Setup Rust
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
-        toolchain: stable
-        override: true
         components: rustfmt, clippy
     
     - name: Cache Rust dependencies
@@ -76,10 +74,7 @@ jobs:
       run: npm run compile
     
     - name: Setup Rust for pylight binary
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        override: true
+      uses: dtolnay/rust-toolchain@stable
     
     - name: Cache Rust dependencies
       uses: actions/cache@v3
@@ -145,11 +140,9 @@ jobs:
       run: npm ci
     
     - name: Setup Rust
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
-        toolchain: stable
-        override: true
-        target: ${{ matrix.target }}
+        targets: ${{ matrix.target }}
     
     - name: Cache Rust dependencies
       uses: actions/cache@v3


### PR DESCRIPTION
## Summary
- Replace deprecated `actions-rs/toolchain@v1` action with `dtolnay/rust-toolchain@stable`
- Fixes GitHub Actions warning about deprecated `set-output` command

## Problem
The CI workflow was showing this warning:
```
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files.
```

This was caused by the outdated `actions-rs/toolchain@v1` action which hasn't been updated since GitHub deprecated the `set-output` command.

## Solution
Replace all instances of `actions-rs/toolchain@v1` with `dtolnay/rust-toolchain@stable`:
- This action is actively maintained and uses the new environment files approach
- Maintains the same functionality with cleaner syntax
- No changes to CI behavior, just using a modern action

## Test plan
- [ ] Verify CI passes on this PR
- [ ] Confirm no more deprecation warnings in GitHub Actions logs

🤖 Generated with [Claude Code](https://claude.ai/code)