### PR TITLE
chore: bump version to 0.2.2

### DIFF
--- a/pydance/package.json
+++ b/pydance/package.json
@@ -2,7 +2,7 @@
     "name": "pydance",
     "displayName": "Pydance",
     "description": "Python language server that provides high-performance workspace symbol search for large Python codebases",
-    "version": "0.2.1",
+    "version": "0.2.2",
     "publisher": "ToughType",
     "icon": "images/pydance-logo.png",
     "repository": {


### PR DESCRIPTION
## Summary
- Bumps pydance version from 0.2.1 to 0.2.2

## Test plan
- CI tests should pass
- Version update only, no functional changes

🤖 Generated with [Claude Code](https://claude.ai/code)