### PR TITLE
chore: bump pydance version to 0.3.0

### DIFF
--- a/pydance/package.json
+++ b/pydance/package.json
@@ -2,7 +2,7 @@
     "name": "pydance",
     "displayName": "Pydance",
     "description": "Python language server that provides high-performance workspace symbol search for large Python codebases",
-    "version": "0.2.2",
+    "version": "0.3.0",
     "publisher": "ToughType",
     "icon": "images/pydance-logo.png",
     "repository": {


### PR DESCRIPTION
## Summary
- Bump pydance extension version from 0.2.2 to 0.3.0
- Version increment reflects the significant performance improvement from switching to nucleo fuzzy matcher

## Test plan
- [ ] Extension compiles successfully
- [ ] Extension loads correctly in VSCode
- [ ] Workspace symbol search still functions as expected

🤖 Generated with [Claude Code](https://claude.ai/code)